### PR TITLE
Fix updateMemberRole not persisting to org members array

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -231,8 +231,15 @@ export default function ChurchScheduleApp() {
 
   const cancelInvite = async (id) => { await db.current.collection('invitations').doc(id).delete(); fetchOrgData(orgId); };
   const updateMemberRole = async (uid, role) => {
-    await db.current.collection('users').doc(uid).update({ role });
-    setMembers(prev => prev.map(m => m.id === uid ? { ...m, role } : m));
+    try {
+      const updatedMembers = members.map(m => m.id === uid ? { ...m, role } : m);
+      await db.current.collection('users').doc(uid).update({ role });
+      await db.current.collection('organizations').doc(orgId).update({ members: updatedMembers });
+      setMembers(updatedMembers);
+    } catch (err) {
+      console.error('Failed to update role:', err);
+      alert('Failed to update role. Please try again.');
+    }
   };
   const removeMember = async (id, name) => {
     if (!window.confirm(`Remove ${name}?`)) return;


### PR DESCRIPTION
The members list is loaded from organizations/{id}.members, but role changes were only writing to users/{uid}. This caused the dropdown to appear to revert on re-render since the org array was never updated.

Now explicitly updates both the users doc and the org members array, and adds error handling so failures are surfaced instead of silent.

https://claude.ai/code/session_01G9Rqb8wCoiBqcPNxUTZUtq