### PR TITLE
Fix role update failing due to Firestore permission on users doc

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,9 @@ export default function ChurchScheduleApp() {
             setSchedule(d.schedule || {});
             setServiceSettings({ ...serviceSettings, ...(d.serviceSettings || {}) });
             setChurchName(d.churchName || '');
+            // Prefer role stored in org members array (updated by admins) over stale users doc
+            const memberInOrg = (d.members || []).find(m => m.id === uid);
+            if (memberInOrg?.role) setUserRole(memberInOrg.role.toLowerCase());
           }
         }
       } else {
@@ -233,7 +236,6 @@ export default function ChurchScheduleApp() {
   const updateMemberRole = async (uid, role) => {
     try {
       const updatedMembers = members.map(m => m.id === uid ? { ...m, role } : m);
-      await db.current.collection('users').doc(uid).update({ role });
       await db.current.collection('organizations').doc(orgId).update({ members: updatedMembers });
       setMembers(updatedMembers);
     } catch (err) {


### PR DESCRIPTION
Updating another user's users/{uid} document is blocked by security rules (users can only write their own doc). This caused the catch block to fire before the org document was ever updated.

- updateMemberRole now only writes to organizations/{id}.members where admins/owners have write access
- loadUserData now prefers the role from the org members array over the users doc, so role changes take effect on the affected user's next login

https://claude.ai/code/session_01G9Rqb8wCoiBqcPNxUTZUtq