### PR TITLE
Fix Generate button not visible on mobile calendar view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -435,7 +435,7 @@ export default function ChurchScheduleApp() {
 
               {/* Calendar controls */}
               {view === 'calendar' && (
-                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                <div className="calendar-controls" style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
                   {/* Month navigation */}
                   <div style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'var(--surface)', border: '1.5px solid var(--border)', borderRadius: 'var(--radius-md)', padding: '2px' }}>
                     <button
@@ -490,7 +490,7 @@ export default function ChurchScheduleApp() {
                   </div>
 
                   {['owner', 'admin'].includes(userRole) && (
-                    <button className="btn-primary" onClick={handleGenerateSchedule}>
+                    <button className="btn-primary generate-btn" onClick={handleGenerateSchedule}>
                       <IconZap /> Generate
                     </button>
                   )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1002,6 +1002,15 @@ h1, h2, h3, h4, h5, h6 {
   .app-main { padding: 20px 16px; padding-bottom: calc(var(--bottom-nav-height) + 20px); }
   .page-title { font-size: 22px; }
 
+  /* Calendar toolbar: lay out full-width so the Generate button is always
+     visible instead of wrapping off the row on narrow screens. */
+  .calendar-controls { width: 100%; }
+  .calendar-controls .generate-btn {
+    flex: 1 1 100%;
+    justify-content: center;
+    padding: 12px 18px;
+  }
+
   /* Modal bottom sheets */
   .member-modal-overlay {
     padding: 0;


### PR DESCRIPTION
On narrow viewports the calendar toolbar's month-nav pill and Actions button filled the first flex row, forcing the Generate button to wrap and become effectively hidden. Give the toolbar and button classes and, under the mobile breakpoint, make the controls full-width with Generate on its own full-width row so it is always visible and tappable.