### PR TITLE
Surface real photo-upload errors instead of generic message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,7 +110,11 @@ export default function ChurchScheduleApp() {
         if (!window.firebase.apps.length) window.firebase.initializeApp(FIREBASE_CONFIG);
         auth.current = window.firebase.auth();
         db.current = window.firebase.firestore();
-        if (typeof window.firebase.storage === 'function') storage.current = window.firebase.storage();
+        if (typeof window.firebase.storage === 'function') {
+          storage.current = window.firebase.storage();
+        } else {
+          console.error('Firebase Storage SDK failed to load — photo uploads will be unavailable.');
+        }
 
         auth.current.onAuthStateChanged((u) => {
           setUser(u);

--- a/src/components/modals/MemberProfileModal.jsx
+++ b/src/components/modals/MemberProfileModal.jsx
@@ -55,14 +55,18 @@ export default function MemberProfileModal({
 
   const handlePhotoUpload = async (e) => {
     const file = e.target.files[0];
-    if (!file || !storage) return alert('Storage not available.');
+    if (!file) return;
+    if (!storage) return alert('Photo upload is unavailable: file storage failed to initialize. Please reload the page and try again.');
     setUploading(true);
     try {
       const ref = storage.ref(`profile_pics/${editingMember.id}`);
       await ref.put(file);
       const url = await ref.getDownloadURL();
       setEditingMember({ ...editingMember, photoURL: url });
-    } catch (err) { alert('Upload failed.'); }
+    } catch (err) {
+      console.error('Photo upload failed:', err);
+      alert(`Upload failed: ${[err?.code, err?.message].filter(Boolean).join(' — ') || 'Unknown error'}`);
+    }
     setUploading(false);
   };
 

--- a/src/components/pages/AccountPage.jsx
+++ b/src/components/pages/AccountPage.jsx
@@ -15,7 +15,8 @@ export default function AccountPage({ user, memberData, onUpdate, onDelete, onBa
 
   const handlePhotoUpload = async (e) => {
     const file = e.target.files[0];
-    if (!file || !storage) return;
+    if (!file) return;
+    if (!storage) return alert('Photo upload is unavailable: file storage failed to initialize. Please reload the page and try again.');
     setUploading(true);
     try {
       const ref = storage.ref(`profile_pics/${user.uid}`);
@@ -24,7 +25,10 @@ export default function AccountPage({ user, memberData, onUpdate, onDelete, onBa
       const updated = { ...form, photoURL: url };
       setForm(updated);
       await onUpdate(updated);
-    } catch (err) { alert('Upload failed.'); }
+    } catch (err) {
+      console.error('Photo upload failed:', err);
+      alert(`Upload failed: ${[err?.code, err?.message].filter(Boolean).join(' — ') || 'Unknown error'}`);
+    }
     setUploading(false);
   };
 


### PR DESCRIPTION
Photo uploads failed with an opaque 'Upload failed.' alert that hid the underlying Firebase Storage error. Show the actual error code/message, log it to the console, distinguish the storage-not-initialized case from upload errors, and log when the Storage SDK fails to load. This exposes the true cause (e.g. storage rules, bucket/plan, CORS) for diagnosis.