### PR TITLE
Fix mobile responsiveness for modal sidebar, nav tabs, and calendar h…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -304,13 +304,18 @@ export default function ChurchScheduleApp() {
         .member-modal-tabs::-webkit-scrollbar { display: none; }
         .member-modal-body { flex: 1; padding: 32px; overflow-y: auto; }
         .member-modal-footer { padding: 20px 32px; border-top: 1px solid #eee; display: flex; justify-content: space-between; align-items: center; background: #fff; flex-wrap: wrap; gap: 8px; }
+        .main-nav { overflow-x: auto; scrollbar-width: none; }
+        .main-nav::-webkit-scrollbar { display: none; }
         @media (max-width: 640px) {
           .member-modal-overlay { padding: 0; align-items: flex-end; }
           .member-modal-wrap { flex-direction: column; max-width: 100%; max-height: 95dvh; border-radius: 20px 20px 0 0; }
-          .member-modal-sidebar { width: 100%; border-right: none; border-bottom: 1px solid #eee; padding: 16px; }
-          .member-modal-body { padding: 16px; }
+          .member-modal-sidebar { width: 100%; border-right: none; border-bottom: 1px solid #eee; padding: 16px; max-height: 45vh; }
+          .member-modal-content { min-height: 0; }
+          .member-modal-body { padding: 16px; min-height: 0; }
           .member-modal-footer { padding: 12px 16px; }
           .nav-tab { padding: 12px 14px; font-size: 13px; white-space: nowrap; }
+          .cal-header-outer { flex-wrap: wrap; }
+          .cal-header-right { flex-wrap: wrap; width: 100%; justify-content: flex-end; }
         }
       `}</style>
 
@@ -343,10 +348,10 @@ export default function ChurchScheduleApp() {
           <SettingsPage onBack={() => setCurrentPage('dashboard')} serviceSettings={serviceSettings} setServiceSettings={setServiceSettings} userRole={userRole} user={user} members={members} pendingInvites={pendingInvites} cancelInvite={cancelInvite} generateInviteLink={generateInviteLink} updateMemberRole={updateMemberRole} removeMember={removeMember} churchName={churchName} setChurchName={setChurchName} />
         ) : (
           <>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+            <div className="cal-header-outer" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
               <h2 style={{ color: '#1e3a5f', margin: 0, fontSize: '28px', fontWeight: '800' }}>{churchName || 'Your Congregation'}</h2>
               {view === 'calendar' && (
-                <div style={{ display: 'flex', gap: '10px', position: 'relative' }} ref={actionsRef}>
+                <div className="cal-header-right" style={{ display: 'flex', gap: '10px', position: 'relative' }} ref={actionsRef}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                       <button className="btn-secondary" onClick={() => setSelectedMonth(new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() - 1))}>←</button>
                       <span style={{ fontWeight: '800', minWidth: '140px', textAlign: 'center' }}>{selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</span>
@@ -372,7 +377,7 @@ export default function ChurchScheduleApp() {
             </div>
 
             {/* RESTORED: SERVICES TAB BUTTON */}
-            <nav style={{ display: 'flex', background: 'white', borderRadius: '12px 12px 0 0', borderBottom: '1px solid #e5e7eb', marginBottom: '32px' }}>
+            <nav className="main-nav" style={{ display: 'flex', background: 'white', borderRadius: '12px 12px 0 0', borderBottom: '1px solid #e5e7eb', marginBottom: '32px' }}>
               <button className={'nav-tab ' + (view === 'directory' ? 'active' : '')} onClick={() => setView('directory')}>👥 Directory</button>
               <button className={'nav-tab ' + (view === 'calendar' ? 'active' : '')} onClick={() => setView('calendar')}>📅 Teaching Calendar</button>
               <button className={'nav-tab ' + (view === 'services' ? 'active' : '')} onClick={() => setView('services')}>🛠️ Service Plans</button>


### PR DESCRIPTION
…eader

Three issues on mobile:
1. Modal sidebar had no max-height so all form fields expanded to full height, pushing the tab bar off-screen and making fields unreachable. Fixed with max-height: 45vh + min-height: 0 on the content area.
2. Main nav tabs and member modal tabs had no overflow-x handling, causing them to clip off-screen. Added main-nav class with overflow-x: auto.
3. Calendar header controls (month nav + Actions + Generate) did not wrap on narrow screens. Added cal-header-outer / cal-header-right classes that enable flex-wrap at 640px.

https://claude.ai/code/session_01G9Rqb8wCoiBqcPNxUTZUtq