### PR TITLE
Harden mobile calendar controls and clarify assign empty state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -596,7 +596,11 @@ export default function ChurchScheduleApp() {
 
             {members.filter(m => m.isSpeaker && m.availability?.[assigningSlot.serviceType]).length === 0 ? (
               <div className="empty-state" style={{ padding: '30px 0' }}>
-                <p>No available speakers for this service type.</p>
+                <p>
+                  {members.some(m => m.isSpeaker)
+                    ? 'No speakers are marked available for this service. Open a member in the Directory and check this service under their availability.'
+                    : 'No speakers yet. Open a member in the Directory and enable "Use in Schedule Generator", then set their availability.'}
+                </p>
               </div>
             ) : (
               <div style={{ maxHeight: 320, overflowY: 'auto', display: 'grid', gap: 6 }}>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1002,14 +1002,24 @@ h1, h2, h3, h4, h5, h6 {
   .app-main { padding: 20px 16px; padding-bottom: calc(var(--bottom-nav-height) + 20px); }
   .page-title { font-size: 22px; }
 
-  /* Calendar toolbar: lay out full-width so the Generate button is always
-     visible instead of wrapping off the row on narrow screens. */
-  .calendar-controls { width: 100%; }
-  .calendar-controls .generate-btn {
-    flex: 1 1 100%;
-    justify-content: center;
-    padding: 12px 18px;
+  /* Calendar toolbar: stack the controls vertically on mobile so the
+     Generate button is always a full-width row and can never wrap off-screen. */
+  .calendar-controls {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
   }
+  .calendar-controls > * { width: 100%; }
+  .calendar-controls .generate-btn {
+    flex: none;
+    width: 100%;
+    justify-content: center;
+    padding: 14px 18px;
+    font-size: 15px;
+  }
+
+  /* Larger tap targets for calendar slots so assignments are easy to tap. */
+  .calendar-bar { min-height: 48px; }
 
   /* Modal bottom sheets */
   .member-modal-overlay {


### PR DESCRIPTION
- Stack the calendar toolbar vertically on mobile (flex-direction: column, full-width children) so the Generate button is always a full-width row and cannot wrap off-screen, instead of relying on flex-wrap ordering.
- Give calendar slots a 48px min tap target on mobile for reliable tapping.
- Replace the opaque 'No available speakers' message in the assign-speaker modal with an actionable hint explaining how to enable a speaker and set availability, so manual assignments aren't silently blocked.